### PR TITLE
fix: Update CI configuration and prevent overwriting

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,2 +1,4 @@
 LICENSE
 README.md
+
+.github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: ./gradlew compileJava
 
   test:
-    needs: [ compile ]
+    needs: [compile]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -37,7 +37,7 @@ jobs:
       - name: Test
         run: ./gradlew test
   publish:
-    needs: [ compile, test ]
+    needs: [compile, test]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
@@ -58,7 +58,6 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-          MAVEN_PUBLISH_REGISTRY_URL: "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-          MAVEN_SIGNATURE_KID: ${{ secrets.MAVEN_SIGNATURE_KID }}
-          MAVEN_SIGNATURE_SECRET_KEY: ${{ secrets.MAVEN_SIGNATURE_SECRET_KEY }}
-          MAVEN_SIGNATURE_PASSWORD: ${{ secrets.MAVEN_SIGNATURE_PASSWORD }}
+          MAVEN_CENTRAL_SECRET_KEY_KEY_ID: ${{ secrets.MAVEN_CENTRAL_SECRET_KEY_KEY_ID }}
+          MAVEN_CENTRAL_SECRET_KEY_PASSWORD: ${{ secrets.MAVEN_CENTRAL_SECRET_KEY_PASSWORD }}
+          MAVEN_CENTRAL_SECRET_KEY: ${{ secrets.MAVEN_CENTRAL_SECRET_KEY }}


### PR DESCRIPTION
In this PR:

- Update ci.yml to fix variables and publish in Maven Central
- Add ci.yml for .fernignore to avoid overwriting when generating SDK